### PR TITLE
Add token authentication and user-related endpoints

### DIFF
--- a/cinema/permisions.py
+++ b/cinema/permisions.py
@@ -1,0 +1,13 @@
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+class IsAdminOrIfAuthenticatedReadOnly(BasePermission):
+    """
+    The request is authenticated as a user, or is a read-only request.
+    """
+
+    def has_permission(self, request, view):
+        if request.user and request.user.is_authenticated:
+            if request.method in SAFE_METHODS:
+                return True
+        return bool(request.user and request.user.is_staff)

--- a/cinema/permissions.py
+++ b/cinema/permissions.py
@@ -7,7 +7,6 @@ class IsAdminOrIfAuthenticatedReadOnly(BasePermission):
     """
 
     def has_permission(self, request, view):
-        if request.user and request.user.is_authenticated:
-            if request.method in SAFE_METHODS:
-                return True
+        if request.method in SAFE_METHODS:
+            return bool(request.user and request.user.is_authenticated)
         return bool(request.user and request.user.is_staff)

--- a/cinema/views.py
+++ b/cinema/views.py
@@ -1,10 +1,11 @@
 from datetime import datetime
-
 from django.db.models import F, Count
-from rest_framework import viewsets
+from rest_framework import viewsets, mixins
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.pagination import PageNumberPagination
-
+from rest_framework.permissions import IsAuthenticated
 from cinema.models import Genre, Actor, CinemaHall, Movie, MovieSession, Order
+from cinema.permisions import IsAdminOrIfAuthenticatedReadOnly
 
 from cinema.serializers import (
     GenreSerializer,
@@ -21,24 +22,41 @@ from cinema.serializers import (
 )
 
 
-class GenreViewSet(viewsets.ModelViewSet):
+class GenreViewSet(viewsets.GenericViewSet,
+                   mixins.ListModelMixin,
+                   mixins.CreateModelMixin):
     queryset = Genre.objects.all()
     serializer_class = GenreSerializer
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAdminOrIfAuthenticatedReadOnly,)
 
 
-class ActorViewSet(viewsets.ModelViewSet):
+class ActorViewSet(viewsets.GenericViewSet,
+                   mixins.ListModelMixin,
+                   mixins.CreateModelMixin):
     queryset = Actor.objects.all()
     serializer_class = ActorSerializer
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAdminOrIfAuthenticatedReadOnly,)
 
 
-class CinemaHallViewSet(viewsets.ModelViewSet):
+class CinemaHallViewSet(viewsets.GenericViewSet,
+                        mixins.ListModelMixin,
+                        mixins.CreateModelMixin):
     queryset = CinemaHall.objects.all()
     serializer_class = CinemaHallSerializer
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAdminOrIfAuthenticatedReadOnly,)
 
 
-class MovieViewSet(viewsets.ModelViewSet):
+class MovieViewSet(mixins.ListModelMixin,
+                   mixins.CreateModelMixin,
+                   mixins.RetrieveModelMixin,
+                   viewsets.GenericViewSet):
     queryset = Movie.objects.prefetch_related("genres", "actors")
     serializer_class = MovieSerializer
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAdminOrIfAuthenticatedReadOnly,)
 
     @staticmethod
     def _params_to_ints(qs):
@@ -76,17 +94,25 @@ class MovieViewSet(viewsets.ModelViewSet):
         return MovieSerializer
 
 
-class MovieSessionViewSet(viewsets.ModelViewSet):
+class MovieSessionViewSet(viewsets.GenericViewSet,
+                          mixins.ListModelMixin,
+                          mixins.CreateModelMixin,
+                          mixins.RetrieveModelMixin,
+                          mixins.UpdateModelMixin,
+                          mixins.DestroyModelMixin, ):
     queryset = (
         MovieSession.objects.all()
         .select_related("movie", "cinema_hall")
         .annotate(
-            tickets_available=F("cinema_hall__rows")
-            * F("cinema_hall__seats_in_row")
-            - Count("tickets")
+            tickets_available=(
+                    F("cinema_hall__rows") * F("cinema_hall__seats_in_row")
+                    - Count("tickets")
+            )
         )
     )
     serializer_class = MovieSessionSerializer
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAdminOrIfAuthenticatedReadOnly,)
 
     def get_queryset(self):
         date = self.request.query_params.get("date")
@@ -118,12 +144,16 @@ class OrderPagination(PageNumberPagination):
     max_page_size = 100
 
 
-class OrderViewSet(viewsets.ModelViewSet):
+class OrderViewSet(viewsets.GenericViewSet,
+                   mixins.ListModelMixin,
+                   mixins.CreateModelMixin, ):
     queryset = Order.objects.prefetch_related(
         "tickets__movie_session__movie", "tickets__movie_session__cinema_hall"
     )
     serializer_class = OrderSerializer
     pagination_class = OrderPagination
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAuthenticated,)
 
     def get_queryset(self):
         return Order.objects.filter(user=self.request.user)

--- a/cinema/views.py
+++ b/cinema/views.py
@@ -5,7 +5,7 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from cinema.models import Genre, Actor, CinemaHall, Movie, MovieSession, Order
-from cinema.permisions import IsAdminOrIfAuthenticatedReadOnly
+from cinema.permissions import IsAdminOrIfAuthenticatedReadOnly
 
 from cinema.serializers import (
     GenreSerializer,

--- a/cinema_service/settings.py
+++ b/cinema_service/settings.py
@@ -125,7 +125,7 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_TZ = False
+USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)

--- a/cinema_service/urls.py
+++ b/cinema_service/urls.py
@@ -3,6 +3,7 @@ from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/user/", include("user.urls", namespace="user")),
     path("api/cinema/", include("cinema.urls", namespace="cinema")),
     path("__debug__/", include("debug_toolbar.urls")),
 ]

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -1,1 +1,28 @@
-# write your code here
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = get_user_model()
+        fields = (
+            "id",
+            "username",
+            "email",
+            "password",
+            "is_staff",
+        )
+        read_only_fields = ("id", "is_staff")
+        extra_kwargs = {"password": {"write_only": True, "min_length": 5}}
+
+    def create(self, validated_data):
+        return get_user_model().objects.create_user(**validated_data)
+
+    def update(self, instance, validated_data):
+        """Update user with encrypted password"""
+        password = validated_data.pop("password", None)
+        user = super().update(instance, validated_data)
+        if password:
+            user.set_password(password)
+            user.save()
+        return user

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,1 +1,11 @@
-# write your code here
+from django.urls import path
+from user.views import UserViewSet, LoginUserView, ManageUserView
+
+urlpatterns = [
+    path("register/", UserViewSet.as_view(), name="create"),
+    path("login/", LoginUserView.as_view(), name="login"),
+    path("me/", ManageUserView.as_view(), name="manage"),
+
+]
+
+app_name = "user"

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,11 +1,10 @@
 from django.urls import path
 from user.views import UserViewSet, LoginUserView, ManageUserView
 
+app_name = "user"
 urlpatterns = [
     path("register/", UserViewSet.as_view(), name="create"),
     path("login/", LoginUserView.as_view(), name="login"),
     path("me/", ManageUserView.as_view(), name="manage"),
 
 ]
-
-app_name = "user"

--- a/user/views.py
+++ b/user/views.py
@@ -1,1 +1,24 @@
-# write your code here
+from rest_framework import generics
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.settings import api_settings
+
+from user.serializers import UserSerializer
+
+
+class UserViewSet(generics.CreateAPIView):
+    serializer_class = UserSerializer
+
+
+class LoginUserView(ObtainAuthToken):
+    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES
+
+
+class ManageUserView(generics.RetrieveUpdateAPIView):
+    serializer_class = UserSerializer
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAuthenticated,)
+
+    def get_object(self):
+        return self.request.user


### PR DESCRIPTION
This PR implements token-based authentication and restricts user access based on their role.

Key changes:
Created UserViewSet, LoginUserView, and ManageUserView

Added registration (/api/user/register/), login (/api/user/login/), and user info update (/api/user/me/) endpoints

Created IsAdminOrIfAuthenticatedReadOnly permission class

Restricted actions in cinema app according to user role:

Genre, CinemaHall, Actor: list & create

Movie: list, create, retrieve

MovieSession: full CRUD

Order: list & create (only for authenticated users)

Configured token authentication across views